### PR TITLE
Fix regression: `labelDetails` in completions not processed

### DIFF
--- a/packages/typescript/src/services/completions/basic.ts
+++ b/packages/typescript/src/services/completions/basic.ts
@@ -83,7 +83,8 @@ export function register(ctx: SharedContext) {
 
 			const { sourceDisplay, isSnippet, labelDetails } = tsEntry;
 			if (sourceDisplay) {
-				item.labelDetails = { description: ts.displayPartsToString(sourceDisplay) };
+				item.labelDetails ??= {};
+				item.labelDetails.description = ts.displayPartsToString(sourceDisplay);
 			}
 
 			if (labelDetails) {

--- a/packages/typescript/src/services/completions/basic.ts
+++ b/packages/typescript/src/services/completions/basic.ts
@@ -12,7 +12,12 @@ export interface Data {
 	uri: string,
 	fileName: string,
 	offset: number,
-	originalItem: ts.CompletionEntry;
+	originalItem: {
+		name: ts.CompletionEntry['name'],
+		source: ts.CompletionEntry['source'],
+		data: ts.CompletionEntry['data'],
+		labelDetails: ts.CompletionEntry['labelDetails'],
+	};
 }
 
 export function register(ctx: SharedContext) {
@@ -138,7 +143,12 @@ export function register(ctx: SharedContext) {
 					uri,
 					fileName,
 					offset,
-					originalItem: tsEntry,
+					originalItem: {
+						name: tsEntry.name,
+						source: tsEntry.source,
+						data: tsEntry.data,
+						labelDetails: tsEntry.labelDetails,
+					},
 				} satisfies Data,
 			};
 		}

--- a/packages/typescript/src/services/completions/basic.ts
+++ b/packages/typescript/src/services/completions/basic.ts
@@ -76,9 +76,14 @@ export function register(ctx: SharedContext) {
 				item.sortText = tsEntry.sortText;
 			}
 
-			const { sourceDisplay, isSnippet } = tsEntry;
+			const { sourceDisplay, isSnippet, labelDetails } = tsEntry;
 			if (sourceDisplay) {
 				item.labelDetails = { description: ts.displayPartsToString(sourceDisplay) };
+			}
+
+			if (labelDetails) {
+				item.labelDetails ??= {};
+				Object.assign(item.labelDetails, labelDetails);
 			}
 
 			item.preselect = tsEntry.isRecommended;

--- a/packages/typescript/src/services/completions/resolve.ts
+++ b/packages/typescript/src/services/completions/resolve.ts
@@ -45,9 +45,15 @@ export function register(ctx: SharedContext) {
 		if (!details)
 			return item;
 
+		if (data.originalItem.labelDetails) {
+			item.labelDetails ??= {};
+			Object.assign(item.labelDetails, data.originalItem.labelDetails);
+		}
+
 		const { sourceDisplay } = details;
 		if (sourceDisplay) {
-			item.labelDetails = { description: ts.displayPartsToString(sourceDisplay) };
+			item.labelDetails ??= {};
+			item.labelDetails.description = ts.displayPartsToString(sourceDisplay);
 		}
 
 		const detailTexts: string[] = [];


### PR DESCRIPTION
`labelDetails` from ts.CompletionEntry was ignored. Its hard to blame as code was moved.

str:

```vue
<script lang="ts">
export default {
    // method snippet such as `activated` completions lacking of label description
}
</script>
```

Also support for it is declared: https://github.com/volarjs/plugins/blob/583ab20ff61b9c4b1381d72d6e048c66f066edd7/packages/typescript/src/configs/getUserPreferences.ts#L32